### PR TITLE
Fixes port security rules deletion

### DIFF
--- a/hyperv/neutron/security_groups_driver.py
+++ b/hyperv/neutron/security_groups_driver.py
@@ -214,6 +214,9 @@ class HyperVSecurityGroupsDriverMixin(object):
         added_provider_rules = port['security_group_rules']
         # Generate the rules
         added_rules = self._generate_rules([port])
+        # Expand wildcard rules
+        expanded_rules = self._sg_gen.expand_wildcard_rules(
+            added_rules[port['id']])
         # Consider added provider rules (if any)
         new_rules = [r for r in added_provider_rules
                      if r not in old_provider_rules]
@@ -226,6 +229,10 @@ class HyperVSecurityGroupsDriverMixin(object):
         # Remove for non provider rules
         remove_rules.extend([r for r in old_provider_rules
                              if r not in added_provider_rules])
+        # Avoid removing or adding rules which are contained in wildcard rules
+        new_rules = [r for r in new_rules if r not in expanded_rules]
+        remove_rules = [r for r in remove_rules if r not in expanded_rules]
+
         LOG.info(_("Creating %(new)s new rules, removing %(old)s "
                    "old rules."),
                  {'new': len(new_rules),
@@ -318,6 +325,26 @@ class SecurityGroupRuleGeneratorR2(SecurityGroupRuleGenerator):
     def compute_new_rules_add(self, old_rules, new_rules):
         add_rules = [r for r in new_rules if r not in old_rules]
         return add_rules, []
+
+    def expand_wildcard_rules(self, rules):
+        wildcard_rules = [
+            r for r in rules
+            if self._get_rule_protocol(r) == ACL_PROP_MAP['default']]
+        rules = []
+        for r in wildcard_rules:
+            rule_copy = r.copy()
+            if rule_copy['direction'] == 'ingress':
+                ip_prefix = 'source_ip_prefix'
+            else:
+                ip_prefix = 'dest_ip_prefix'
+            if ip_prefix not in rule_copy:
+                rule_copy[ip_prefix] = (
+                    ACL_PROP_MAP['address_default'][rule_copy['ethertype']])
+            for proto in list(set(ACL_PROP_MAP['protocol'].keys())):
+                rule_to_add = rule_copy.copy()
+                rule_to_add['protocol'] = proto
+                rules.extend([rule_to_add])
+        return rules
 
     def _get_rule_port_range(self, rule):
         if 'port_range_min' in rule and 'port_range_max' in rule:

--- a/hyperv/tests/unit/neutron/test_security_groups_driver.py
+++ b/hyperv/tests/unit/neutron/test_security_groups_driver.py
@@ -223,6 +223,71 @@ class TestHyperVSecurityGroupsDriver(SecurityGroupRuleTestHelper):
         self.assertNotIn(new_mock_port['device'], self._driver._security_ports)
         mock_method.assert_called_once_with(new_mock_port)
 
+    def test_update_port_filter_security_disabled(self):
+        mock_port = self._get_port()
+        mock_port['port_security_enabled'] = False
+
+        self._driver.update_port_filter(mock_port)
+
+        self.assertFalse(self._driver._utils.remove_all_security_rules.called)
+        self.assertNotIn(mock_port['device'], self._driver._security_ports)
+        self.assertNotIn(mock_port['id'], self._driver._sec_group_rules)
+
+    def test_update_port_filter_security_disabled_existing_rules(self):
+        mock_port = self._get_port()
+        mock_port['port_security_enabled'] = False
+        self._driver._sec_group_rules[mock_port['id']] = mock.ANY
+
+        self._driver.update_port_filter(mock_port)
+
+        self._driver._utils.remove_all_security_rules.assert_called_once_with(
+            mock_port['id'])
+        self.assertNotIn(mock_port['device'], self._driver._security_ports)
+        self.assertNotIn(mock_port['id'], self._driver._sec_group_rules)
+
+    @mock.patch.object(sg_driver.HyperVSecurityGroupsDriver,
+                       '_generate_rules')
+    def test_update_port_filter_existing_wildcard_rules(self, mock_gen_rules):
+        mock_port = self._get_port()
+        new_mock_port = self._get_port()
+        new_mock_port['id'] += '2'
+        new_mock_port['security_group_rules'][0]['ethertype'] += "2"
+
+        fake_rule_new = self._create_security_rule(direction='egress',
+                                                   protocol='udp')
+        fake_wildcard_rule_new = self._create_security_rule(protocol='ANY',
+                                                            direction='egress')
+        fake_expanded_rules = [
+            self._create_security_rule(direction='egress', protocol='tcp'),
+            self._create_security_rule(direction='egress', protocol='udp'),
+            self._create_security_rule(direction='egress', protocol='icmp')]
+        self._driver._sg_gen.expand_wildcard_rules.return_value = (
+            fake_expanded_rules)
+
+        mock_gen_rules.return_value = {
+            new_mock_port['id']: [fake_rule_new, fake_wildcard_rule_new]}
+
+        self._driver._security_ports[mock_port['device']] = mock_port
+        self._driver._sec_group_rules[new_mock_port['id']] = [
+            self._create_security_rule(direction='egress', protocol='icmp')]
+
+        filtered_new_rules = [new_mock_port['security_group_rules'][0],
+                              fake_wildcard_rule_new]
+        filtered_remove_rules = mock_port['security_group_rules']
+
+        self._driver._create_port_rules = mock.MagicMock()
+        self._driver._remove_port_rules = mock.MagicMock()
+        self._driver.update_port_filter(new_mock_port)
+
+        self._driver._sg_gen.expand_wildcard_rules.assert_called_once_with(
+            [fake_rule_new, fake_wildcard_rule_new])
+        self._driver._remove_port_rules.assert_called_once_with(
+            mock_port['id'], filtered_remove_rules)
+        self._driver._create_port_rules.assert_called_once_with(
+            new_mock_port['id'], filtered_new_rules)
+        self.assertEqual(new_mock_port,
+                         self._driver._security_ports[new_mock_port['device']])
+
     def test_remove_port_filter(self):
         mock_port = self._get_port()
         mock_rule = mock.MagicMock()
@@ -453,6 +518,38 @@ class SecurityGroupRuleGeneratorR2TestCase(SecurityGroupRuleR2BaseTestCase):
             [old_rule], [new_rule, old_rule])
 
         self.assertEqual([new_rule], add_rules)
+
+    def test_expand_wildcard_rules(self):
+        egress_wildcard_rule = self._create_security_rule(
+            protocol='ANY',
+            direction='egress')
+        ingress_wildcard_rule = self._create_security_rule(
+            protocol='ANY',
+            direction='ingress')
+        normal_rule = self._create_security_rule()
+        rules = [egress_wildcard_rule, ingress_wildcard_rule, normal_rule]
+
+        actual_expanded_rules = self.sg_gen.expand_wildcard_rules(rules)
+
+        expanded_rules = []
+        for proto in sg_driver.ACL_PROP_MAP['protocol'].keys():
+            expanded_rules.extend(
+                [self._create_security_rule(protocol=proto,
+                                            direction='egress'),
+                 self._create_security_rule(protocol=proto,
+                                            direction='ingress')])
+        diff_expanded_rules = [r for r in expanded_rules
+                               if r not in actual_expanded_rules]
+        self.assertEqual([], diff_expanded_rules)
+
+    def test_expand_no_wildcard_rules(self):
+        normal_rule = self._create_security_rule(direction='egress')
+        another_normal_rule = self._create_security_rule(direction='ingress')
+
+        actual_expanded_rules = self.sg_gen.expand_wildcard_rules(
+            [normal_rule, another_normal_rule])
+
+        self.assertEqual([], actual_expanded_rules)
 
     def test_get_rule_port_range(self):
         rule = self._create_security_rule()


### PR DESCRIPTION
Port security rules might contain rules that apply
to any protocol.

Currently there is no checking to see if a rule
which will be deleted belongs to a security
rule that applies to all protocols.

This patch addresses this issue by adding a check
to make sure the rule can be safely removed.

Closes-Bug: #1634082
Change-Id: Icfa7d77609394a2a7030f68c2643baf309a5de74
(cherry picked from commit 02e2337ac7223f97d78812846defe345372b785e)

Conflicts:
	hyperv/tests/unit/neutron/test_security_groups_driver.py