### PR TITLE
Fixes HyperVSecurityGroupsDriver for ports without security groups

### DIFF
--- a/hyperv/neutron/security_groups_driver.py
+++ b/hyperv/neutron/security_groups_driver.py
@@ -133,7 +133,7 @@ class HyperVSecurityGroupsDriverMixin(object):
         return newports
 
     def prepare_port_filter(self, port):
-        if not port['port_security_enabled']:
+        if not port.get('port_security_enabled'):
             LOG.info(_LI('Port %s does not have security enabled. '
                          'Skipping rules creation.'), port['id'])
             return
@@ -208,7 +208,7 @@ class HyperVSecurityGroupsDriverMixin(object):
         LOG.info(_LI('Aplying port filter.'))
 
     def update_port_filter(self, port):
-        if not port['port_security_enabled']:
+        if not port.get('port_security_enabled'):
             LOG.info(_LI('Port %s does not have security enabled. '
                          'Removing existing rules if any.'), port['id'])
             existing_rules = self._sec_group_rules.pop(port['id'], None)

--- a/hyperv/tests/unit/neutron/test_security_groups_driver.py
+++ b/hyperv/tests/unit/neutron/test_security_groups_driver.py
@@ -178,7 +178,7 @@ class TestHyperVSecurityGroupsDriver(SecurityGroupRuleTestHelper):
 
     def test_prepare_port_filter_security_disabled(self):
         mock_port = self._get_port()
-        mock_port['port_security_enabled'] = False
+        mock_port.pop('port_security_enabled')
 
         self._driver.prepare_port_filter(mock_port)
 
@@ -241,7 +241,7 @@ class TestHyperVSecurityGroupsDriver(SecurityGroupRuleTestHelper):
 
     def test_update_port_filter_security_disabled_existing_rules(self):
         mock_port = self._get_port()
-        mock_port['port_security_enabled'] = False
+        mock_port.pop('port_security_enabled')
         self._driver._sec_group_rules[mock_port['id']] = mock.ANY
 
         self._driver.update_port_filter(mock_port)


### PR DESCRIPTION
If a port has security groups disabled, it might not have the
'port_security_enabled' key.

Change-Id: Ib0152b6b413e60a664bfb1cd4b485490b2c7482f
Closes-Bug: #1659527
(cherry picked from commit bad3da0d60499c725f57c57ee53dea5483d24423)